### PR TITLE
Add mysql Dmaas backup restore testCase

### DIFF
--- a/tests/dmaas_test.py
+++ b/tests/dmaas_test.py
@@ -598,6 +598,44 @@ class TestDmaas:
             .open_schedules_page() \
             .verify_restore_status("Success")
 
+        @pytest.mark.dmaasJivaMysql
+        def test_verify_restore_jiva_mysql_dmaas_schedule(self, driver, url, minio):
+            print("Restore  Jiva dmaas schedule")
+            Platform(driver).launch(url) \
+                .login("oep.user@mayadata.io", "OEPuser@123") \
+                .open_clusters_page() \
+                .open_cluster_details("oep-cluster-cluster2", "Active") \
+                .open_applications_page() \
+                .search_application("wordpress-mysql") \
+                .click_on_application("wordpress-mysql", "Deployment", "jiva-mysql") \
+                .verify_application_type("wordpress-mysql", "Deployment") \
+                .verify_volume_cas_type("mysql-pv-jiva-claim", "Jiva") \
+                .click_dmass_button() \
+                .click_new_schedule_button() \
+                .select_cloud_provider("MINIO") \
+                .click_add_cloud_credential_button() \
+                .set_cloud_credential("MINIO", "minio-cred") \
+                .select_provider_credential("minio-cred") \
+                .enter_minio_url(minio) \
+                .select_interval("Hourly") \
+                .select_minutes("05") \
+                .select_hour("03") \
+                .click_schedule_now_button() \
+                .confirm_aws_schedule() \
+                .verify_dmass_schedule_present() \
+                .search_dmaas_schedule() \
+                .click_dmaas_schedule("Active") \
+                .verify_status_of_backups("Completed") \
+                .click_on_restore_dmaas_schedule_icon() \
+                .select_restore_cluster("oep-cluster-cluster3") \
+                .click_start_restore_button() \
+                .click_restore_link() \
+                .open_dmaas_page() \
+                .find_schedule() \
+                .enter_schedule() \
+                .open_schedules_page() \
+                .verify_restore_status("Success")
+
     @pytest.mark.dmaasHostpathMinio
     def test_verify_restore_hostpath_minio_dmaas_schedule(self, driver, url, minio):
         print("Restore hostptah dmaas schedule")

--- a/tests/dmaas_test.py
+++ b/tests/dmaas_test.py
@@ -599,7 +599,7 @@ class TestDmaas:
             .verify_restore_status("Success")
 
         @pytest.mark.dmaasJivaMysql
-        def test_verify_restore_jiva_mysql_dmaas_schedule(self, driver, url, minio):
+        def test_verify_restore_jiva_mysql_dmaas_schedule(self, driver, url, region):
             print("Restore  Jiva dmaas schedule")
             Platform(driver).launch(url) \
                 .login("oep.user@mayadata.io", "OEPuser@123") \
@@ -612,11 +612,11 @@ class TestDmaas:
                 .verify_volume_cas_type("mysql-pv-jiva-claim", "Jiva") \
                 .click_dmass_button() \
                 .click_new_schedule_button() \
-                .select_cloud_provider("MINIO") \
+                .select_cloud_provider("AWS") \
                 .click_add_cloud_credential_button() \
-                .set_cloud_credential("MINIO", "minio-cred") \
-                .select_provider_credential("minio-cred") \
-                .enter_minio_url(minio) \
+                .set_cloud_credential("AWS", "aws-cred") \
+                .select_provider_credential("aws-cred") \
+                .select_region(region) \
                 .select_interval("Hourly") \
                 .select_minutes("05") \
                 .select_hour("03") \


### PR DESCRIPTION
 #### ISSUE :

https://github.com/mayadata-io/oep-e2e/issues/700

#### Short Description :

- New gui test case for Mysql application backup and restore on Minio cloudProvider .
- mysql application used `openebs-jiva-default` storege class .

#### Logs of testCase ran in Local

<img width="1440" alt="Screenshot 2020-06-25 at 12 28 13 PM" src="https://user-images.githubusercontent.com/40464957/85683791-2dc9ef80-b6eb-11ea-8c7f-5bc9fb95b6b2.png">



Signed-off-by: bhaskarhc <hcbhaskar7@gmail.com>